### PR TITLE
Point `package.json` to the correct `main` module

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "babel-webpack-tree-shaking",
   "version": "1.0.0",
   "description": "Tree-shaking example with Babel and Webpack",
-  "main": "index.js",
+  "main": "dist/car.es2015.prod.bundle.js",
   "scripts": {
     "webpack": "webpack --config webpack.config.js",
     "webpack-prod": "webpack --config webpack.prod.config.js",


### PR DESCRIPTION
The `index.js` file does not exist in this project, so we should point to the actual entry point.
